### PR TITLE
Fixes EDumdum/iso-17442-java#1

### DIFF
--- a/src/main/java/org/edumdum/iso/Iso17442.java
+++ b/src/main/java/org/edumdum/iso/Iso17442.java
@@ -1,11 +1,13 @@
 package org.edumdum.iso;
 
-import org.edumdum.iso.Iso7064;
+import java.util.regex.Pattern;
 
 public class Iso17442
 {
     private static final String FORMAT_ISVALID = "^[0-9A-Z]{18}[0-9]{2}$";
     private static final String FORMAT_GENERATE = "^[0-9A-Z]{18}$";
+    private static final Pattern PATTERN_ISVALID = Pattern.compile(FORMAT_ISVALID);
+    private static final Pattern PATTERN_GENERATE = Pattern.compile(FORMAT_GENERATE);
 
 	/**
 	 * Check requirements.
@@ -19,9 +21,14 @@ public class Iso17442
 	public static boolean isValid(String rawValue)
 		throws IllegalArgumentException
 	{                
-		if (rawValue == null || !rawValue.matches(FORMAT_ISVALID))
+		if (rawValue == null || !PATTERN_ISVALID.matcher(rawValue).matches())
 		{
 			throw new IllegalArgumentException(String.format("Invalid data format; expecting '%s', found: '%s'.", FORMAT_ISVALID, rawValue));
+		}
+		int n = Integer.parseInt(rawValue.substring(18, 20));
+		if (!(2 <= n && n <= 98))
+		{
+			return false;
 		}
 
 		return Iso7064.computeWithoutCheck(rawValue) == 1;
@@ -39,7 +46,7 @@ public class Iso17442
     public static String generate(String rawValue)
         throws IllegalArgumentException
     {                
-        if (rawValue == null || !rawValue.matches(FORMAT_GENERATE))
+        if (rawValue == null || !PATTERN_GENERATE.matcher(rawValue).matches())
         {
             throw new IllegalArgumentException(String.format("Invalid data format; expecting '%s', found: '%s'.", FORMAT_GENERATE, rawValue));
         }

--- a/src/test/java/org/edumdum/iso/Iso17442Test.java
+++ b/src/test/java/org/edumdum/iso/Iso17442Test.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.fail;
 import java.util.HashMap;
 import java.util.function.Function;
 
-import org.edumdum.iso.Iso7064;
 import org.junit.Test;
 
 public class Iso17442Test
@@ -34,6 +33,17 @@ public class Iso17442Test
         DATA_ISVALID.put("7245005WBNJAFHBD0S30", true);
         DATA_ISVALID.put("724500VKKSH9QOLTFR81", true);
         DATA_ISVALID.put("724500884QS64MG71N64", true);
+        DATA_ISVALID.put("315700BBRQHDWX6SHZ97", true);
+        DATA_ISVALID.put("00000000000000000098", true);
+
+//      with 65 as remainder
+        DATA_ISVALID.put("315700BBRQHDWX6SHZ00", false);
+        DATA_ISVALID.put("00000000000000006500", false);
+        DATA_ISVALID.put("00000000000000016200", false);
+//      multiple of 97
+        DATA_ISVALID.put("00000000000000000001", false);
+        DATA_ISVALID.put("00000000000000009701", false);
+        DATA_ISVALID.put("00000000000000019401", false);
 	}
 
 	private static final String EXCEPTION_TEMPLATE_GENERATE = "Invalid data format; expecting '^[0-9A-Z]{18}$', found: '%s'.";	


### PR DESCRIPTION
The LEI "315700BBRQHDWX6SHZ00" was detected as valid but it's not. Key must be in range [02 - 98].
If the key is not in the valid range `isValid` returns false.

Compiled pattern is stored to speed up pattern matching.
